### PR TITLE
V22F-656 moved error code from receiving thread to main thread

### DIFF
--- a/IPCLib/Socket.cpp
+++ b/IPCLib/Socket.cpp
@@ -19,6 +19,8 @@ bool ReceivingThread::HasReceivedMessage() const
     return m_received;
 }
 
+/// @brief  Returns an error code if there was an error in this thread
+/// @return The error code
 int ReceivingThread::GetErrorCode() const
 {
     return m_error;
@@ -31,6 +33,7 @@ void ReceivingThread::StartReceive()
     m_receiving = true;
 }
 
+/// @brief Stops the receiving thread
 void ReceivingThread::Stop()
 {
     m_stop = true;
@@ -115,6 +118,7 @@ void Socket::Stop()
 /// @brief				Awaits until data has been written to the socket
 /// @param p_dataBuffer The data buffer for storing the data
 /// @param p_size		The size of the buffer
+/// @return             An error code
 int Socket::AwaitData(char* p_dataBuffer, int p_size)
 {
     if (!m_externalReceive)

--- a/IPCLib/Socket.h
+++ b/IPCLib/Socket.h
@@ -20,10 +20,11 @@
 #define IPCLIB_WARNING(p_message) \
     std::cerr << p_message << std::endl;
 
-#define WSA_ERROR           -1
-#define IPCLIB_SERVER_ERROR 1
-#define IPCLIB_CLIENT_ERROR 2
-#define IPCLIB_SUCCEED      0
+#define WSA_ERROR            -1
+#define IPCLIB_SERVER_ERROR  1
+#define IPCLIB_CLIENT_ERROR  2
+#define IPCLIB_SUCCEED       0
+#define IPCLIB_RECEIVE_ERROR 3
 
 /// @brief A worker thread that can be commanded to receive data
 class IPCLIB_EXPORT ReceivingThread
@@ -32,6 +33,8 @@ public:
     explicit ReceivingThread(const std::function<void()>& p_receiveDataFunc);
 
     bool HasReceivedMessage() const;
+
+    int GetErrorCode() const;
 
     void StartReceive();
 
@@ -48,6 +51,8 @@ private:
     bool m_receiving = false;
     bool m_received = false;
 
+    int m_error = 0;
+
     std::function<void()>* m_receiveDataFunc = nullptr;
 
     std::thread* m_thread = nullptr;
@@ -59,7 +64,7 @@ class IPCLIB_EXPORT Socket
 public:
     void ReceiveDataAsync();
 
-    void AwaitData(char* p_dataBuffer, int p_size);
+    int AwaitData(char* p_dataBuffer, int p_size);
 
     bool GetData(char* p_dataBuffer, int p_size);
 

--- a/IPCTests/SocketTest.cpp
+++ b/IPCTests/SocketTest.cpp
@@ -35,7 +35,10 @@ bool SendDataToServer(ServerSocket& p_server, ClientSocket& p_client, const char
         return false;
     }
 
-    p_server.AwaitData(dataBuffer, dataBufferSize);
+    if(p_server.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
+    {
+        return false;
+    }
 
     return TestMessageEqual(p_message, dataBuffer, p_messageLength);
 }
@@ -92,7 +95,10 @@ bool SendDataToClient(ServerSocket& p_server, ClientSocket& p_client, const char
         return false;
     }
 
-    p_client.AwaitData(dataBuffer, dataBufferSize);
+    if(p_client.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
+    {
+        return false;   
+    }
 
     return TestMessageEqual(p_message, dataBuffer, p_messageLength);
 }
@@ -153,7 +159,7 @@ void AwaitingServer()
     ASSERT_EQ(server.Initialize(), IPCLIB_SUCCEED);
     server.AwaitClientConnection();
     char buffer[32];
-    server.AwaitData(buffer, 32);
+    ASSERT_EQ(server.AwaitData(buffer, 32),IPCLIB_SUCCEED);
     ASSERT_EQ(server.SendData("OK", 2), IPCLIB_SUCCEED);
     TestMessageEqual("OK", buffer, 2);
 }
@@ -167,7 +173,7 @@ TEST(SocketTests, AwaitConnectionTest)
     client.ReceiveDataAsync();
     ASSERT_EQ(client.SendData("OK", 2), IPCLIB_SUCCEED);
     char buffer[32];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, client.AwaitData(buffer, 32));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(client.AwaitData(buffer, 32),IPCLIB_SUCCEED));
     TestMessageEqual("OK", buffer, 2);
     t.join();
 }
@@ -279,7 +285,7 @@ TEST(SocketTests, DontReceiveTwice)
     server.ReceiveDataAsync();
     ASSERT_EQ(client.SendData("hi1", 3), IPCLIB_SUCCEED);
     char buffer[20];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, server.AwaitData(buffer, 20));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
     ASSERT_TRUE(TestMessageEqual(buffer, "hi1", 3));
     ASSERT_FALSE(server.GetData(buffer, 20));
     server.ReceiveDataAsync();
@@ -292,7 +298,7 @@ TEST(SocketTests, DontReceiveTwice)
     server.ReceiveDataAsync();
     ASSERT_FALSE(server.GetData(buffer, 20));
     ASSERT_EQ(client.SendData("hi3", 3), IPCLIB_SUCCEED);
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, server.AwaitData(buffer, 20));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
     ASSERT_TRUE(TestMessageEqual(buffer, "hi3", 3));
 }
 
@@ -304,7 +310,7 @@ TEST(SocketTests, SendNullOp)
     char data[4]{"x\0x"};
     ASSERT_EQ(client.SendData(data, 3), IPCLIB_SUCCEED);
     char buffer[20];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, server.AwaitData(buffer, 20));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
     ASSERT_TRUE(buffer[0] == 'x' && buffer[1] == '\0' && buffer[2] == 'x');
 }
 
@@ -347,9 +353,20 @@ TEST(SocketTests, DoubleClientInitializeTest)
     ASSERT_THROW(client.Initialize(), std::runtime_error);
 }
 
+/// @brief should not throw when initializing twice
 TEST(SocketTests, ClientFailedInitializeTwiceTest)
 {
     ClientSocket client;
     client.Initialize();
     client.Initialize();  // should not throw
+}
+
+TEST(SocketTests, ReceivingThreadThrow)
+{
+    CONNECT();
+    char buffer[20];
+    client.ReceiveDataAsync();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    server.~ServerSocket();
+    ASSERT_EQ(client.AwaitData(buffer, 20),IPCLIB_RECEIVE_ERROR);
 }

--- a/IPCTests/SocketTest.cpp
+++ b/IPCTests/SocketTest.cpp
@@ -35,7 +35,7 @@ bool SendDataToServer(ServerSocket& p_server, ClientSocket& p_client, const char
         return false;
     }
 
-    if(p_server.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
+    if (p_server.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
     {
         return false;
     }
@@ -95,9 +95,9 @@ bool SendDataToClient(ServerSocket& p_server, ClientSocket& p_client, const char
         return false;
     }
 
-    if(p_client.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
+    if (p_client.AwaitData(dataBuffer, dataBufferSize) != IPCLIB_SUCCEED)
     {
-        return false;   
+        return false;
     }
 
     return TestMessageEqual(p_message, dataBuffer, p_messageLength);
@@ -159,7 +159,7 @@ void AwaitingServer()
     ASSERT_EQ(server.Initialize(), IPCLIB_SUCCEED);
     server.AwaitClientConnection();
     char buffer[32];
-    ASSERT_EQ(server.AwaitData(buffer, 32),IPCLIB_SUCCEED);
+    ASSERT_EQ(server.AwaitData(buffer, 32), IPCLIB_SUCCEED);
     ASSERT_EQ(server.SendData("OK", 2), IPCLIB_SUCCEED);
     TestMessageEqual("OK", buffer, 2);
 }
@@ -173,7 +173,7 @@ TEST(SocketTests, AwaitConnectionTest)
     client.ReceiveDataAsync();
     ASSERT_EQ(client.SendData("OK", 2), IPCLIB_SUCCEED);
     char buffer[32];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(client.AwaitData(buffer, 32),IPCLIB_SUCCEED));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(client.AwaitData(buffer, 32), IPCLIB_SUCCEED));
     TestMessageEqual("OK", buffer, 2);
     t.join();
 }
@@ -285,7 +285,7 @@ TEST(SocketTests, DontReceiveTwice)
     server.ReceiveDataAsync();
     ASSERT_EQ(client.SendData("hi1", 3), IPCLIB_SUCCEED);
     char buffer[20];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20), IPCLIB_SUCCEED));
     ASSERT_TRUE(TestMessageEqual(buffer, "hi1", 3));
     ASSERT_FALSE(server.GetData(buffer, 20));
     server.ReceiveDataAsync();
@@ -298,7 +298,7 @@ TEST(SocketTests, DontReceiveTwice)
     server.ReceiveDataAsync();
     ASSERT_FALSE(server.GetData(buffer, 20));
     ASSERT_EQ(client.SendData("hi3", 3), IPCLIB_SUCCEED);
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20), IPCLIB_SUCCEED));
     ASSERT_TRUE(TestMessageEqual(buffer, "hi3", 3));
 }
 
@@ -310,7 +310,7 @@ TEST(SocketTests, SendNullOp)
     char data[4]{"x\0x"};
     ASSERT_EQ(client.SendData(data, 3), IPCLIB_SUCCEED);
     char buffer[20];
-    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20),IPCLIB_SUCCEED));
+    ASSERT_DURATION_LE(AWAIT_MESSAGE_TIMEOUT, ASSERT_EQ(server.AwaitData(buffer, 20), IPCLIB_SUCCEED));
     ASSERT_TRUE(buffer[0] == 'x' && buffer[1] == '\0' && buffer[2] == 'x');
 }
 
@@ -361,6 +361,7 @@ TEST(SocketTests, ClientFailedInitializeTwiceTest)
     client.Initialize();  // should not throw
 }
 
+/// @brief Checks if an error code can be received from the receiving thread
 TEST(SocketTests, ReceivingThreadThrow)
 {
     CONNECT();
@@ -368,5 +369,5 @@ TEST(SocketTests, ReceivingThreadThrow)
     client.ReceiveDataAsync();
     std::this_thread::sleep_for(std::chrono::seconds(1));
     server.~ServerSocket();
-    ASSERT_EQ(client.AwaitData(buffer, 20),IPCLIB_RECEIVE_ERROR);
+    ASSERT_EQ(client.AwaitData(buffer, 20), IPCLIB_RECEIVE_ERROR);
 }


### PR DESCRIPTION
This PR will support [this](https://github.com/red-panda-productions/SDALib/pull/23) PR, so that we can check the await data function for error codes. What is also nice to know is that this PR can now allow the user of the library to decide if they want to throw when an error occurs, as the library never throws an exception itself, but either catches the error internally or returns an error code.